### PR TITLE
Let's not prefix the addresses with sf until we make them an sf object

### DIFF
--- a/2022/r-sf-mapping-geo-analysis/r-sf-mapping-geo-analysis.Rmd
+++ b/2022/r-sf-mapping-geo-analysis/r-sf-mapping-geo-analysis.Rmd
@@ -73,7 +73,7 @@ We can now convert the geocoded data frame of San Francisco addresses to an **sf
 
 ```{r}
 # convert to sf object with equirectangular projection (EPSG:4326)
-sf_addresses <- sf_addresses %>%
+sf_addresses <- addresses %>%
   st_as_sf(coords = c("long","lat"),
            crs = st_crs("EPSG:4326"))
 

--- a/2022/r-sf-mapping-geo-analysis/r-sf-mapping-geo-analysis.Rmd
+++ b/2022/r-sf-mapping-geo-analysis/r-sf-mapping-geo-analysis.Rmd
@@ -53,16 +53,16 @@ Next we will use the [**tidygeocoder**](https://jessecambon.github.io/tidygeocod
 
 ```{r}
 # load addresses data
-sf_addresses <- read_tsv("sf_test_addresses.tsv")
+addresses <- read_tsv("sf_test_addresses.tsv")
 
 # geocode
-sf_addresses <- geocode(sf_addresses,
+addresses <- geocode(sf_addresses,
                         address = address,
                         method = "arcgis",
                         full_results = TRUE)
 
 # look at the geocoded data
-view(sf_addresses)
+view(addresses)
 ```
 
 Including `full_results = TRUE` in this code provides some information about the estimated accuracy of the geocoding.


### PR DESCRIPTION
I found it a little confusing that sometimes sf stands for simple features and other times it stands for San Francisco.